### PR TITLE
Allow setting our own textures for iChannels

### DIFF
--- a/ShaderToyLite.js
+++ b/ShaderToyLite.js
@@ -245,7 +245,7 @@ function ShaderToyLite(canvasId) {
             }
             for (let i = 0; i < 4; i++) {
                 var s = config[`iChannel${i}`];
-                if (s == "A" || s == "B" || s == "C" || s == "D") {
+                if (s) {
                     ichannels[key][i] = s;
                 }
             }


### PR DESCRIPTION
Hi! Thanks so much for ShaderToyLite! It's exactly what I needed.

I think this change is needed to make the example work in the README with `iChannel0: 'rock'`. At least it works for my case!